### PR TITLE
Add CI workflow with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository demonstrates a simple monorepo using **pnpm workspaces** and **T
 - `pnpm build` – build all packages
 - `pnpm start` – start compiled applications
 - `pnpm lint` – run ESLint across the repo
+- `pnpm test` – run unit tests using Vitest
 
 Environment variables are loaded from the root `.env` file in all packages.
 Set `NEXT_PUBLIC_API_URL` to the API base URL (default `http://localhost:3001`).
@@ -75,6 +76,12 @@ To build and run the API:
 docker build -t new-app-api apps/api
 docker run -p 3001:3001 new-app-api
 ```
+
+## CI
+
+All pushes and pull requests trigger GitHub Actions defined in
+`.github/workflows/ci.yml`. The workflow installs dependencies,
+runs `pnpm lint`, `pnpm test` and `pnpm build`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,16 @@
     "build": "turbo run build",
     "start": "turbo run start",
     "postinstall": "pnpm --filter @new-app/api exec prisma generate || true",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "vitest run"
   },
   "devDependencies": {
     "turbo": "^1.10.12",
     "@types/node": "^20.11.21",
     "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
-    "@typescript-eslint/parser": "^7.8.0"
+    "@typescript-eslint/parser": "^7.8.0",
+    "vitest": "^1.5.1"
   },
   "engines": {
     "node": "^18"

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+import { GameSchema } from './index'
+
+describe('GameSchema', () => {
+  it('parses valid data', () => {
+    const data = { id: '1', name: 'D&D', gmName: 'Alice', players: ['Bob'] }
+    expect(GameSchema.parse(data)).toEqual(data)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint, tests and build
- add Vitest with a basic schema test
- document new test script and CI in README

## Testing
- `pnpm test`
- `pnpm build` *(fails: Module '"@prisma/client"' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_684805c1b1748327b1d1bb2aadc44455