### PR TITLE
Add Discord authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 DATABASE_URL="file:./dev.db"
 NEXT_PUBLIC_API_URL=http://localhost:3001
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+DISCORD_CALLBACK_URL=http://localhost:3001/auth/discord/callback
+SESSION_SECRET=change-me
+FRONTEND_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 pnpm-lock.yaml
 .turbo
 *.tsbuildinfo
+node-compile-cache/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This repository demonstrates a simple monorepo using **pnpm workspaces** and **T
 
 Environment variables are loaded from the root `.env` file in all packages.
 Set `NEXT_PUBLIC_API_URL` to the API base URL (default `http://localhost:3001`).
+Provide Discord OAuth credentials in `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` and set `DISCORD_CALLBACK_URL`.
+Use `SESSION_SECRET` to configure cookie sessions.
 
 ## Минимальные требования к серверу
 
@@ -58,15 +60,18 @@ pnpm prisma migrate dev --name init
 ## API routes
 
 - `GET /games` – return list of games
-- `POST /games` – create a new game. Body example:
+- `POST /games` – create a new game (GM only). Body example:
 
 ```json
 {
   "name": "D&D",
-  "gmName": "Alice",
   "players": ["Bob", "Charlie"]
 }
 ```
+
+- `GET /me` – current authenticated user
+- `GET /auth/discord` – start Discord OAuth flow
+- `GET /auth/discord/callback` – OAuth callback
 
 ### Docker
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,13 +14,19 @@
     "@new-app/shared": "workspace:*",
     "@prisma/client": "^5.10.2",
     "cors": "^2.8.5",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "express-session": "^1.17.3",
+    "passport": "^0.7.0",
+    "passport-discord": "0.1.4"
   },
   "devDependencies": {
     "ts-node-dev": "^2.0.0",
     "@types/express": "^4.17.21",
     "prisma": "^5.10.2",
     "@types/cors": "^2.8.13",
-    "@types/morgan": "^1.9.4"
+    "@types/morgan": "^1.9.4",
+    "@types/express-session": "^1.17.7",
+    "@types/passport": "^1.0.12",
+    "@types/passport-discord": "0.1.14"
   }
 }

--- a/apps/api/src/express.d.ts
+++ b/apps/api/src/express.d.ts
@@ -1,0 +1,13 @@
+import type { User as AppUser } from '@new-app/shared';
+
+declare global {
+  namespace Express {
+    interface User extends AppUser {}
+    interface Request {
+      user?: AppUser;
+      isAuthenticated(): boolean;
+    }
+  }
+}
+
+export {};

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,19 +1,84 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import dotenv from 'dotenv';
 import path from 'path';
 import cors from 'cors';
 import morgan from 'morgan';
-import { CreateGameSchema } from '@new-app/shared';
+import session from 'express-session';
+import passport from 'passport';
+import { Strategy as DiscordStrategy } from 'passport-discord';
+import { CreateGameSchema, User } from '@new-app/shared';
 import { listGames, createGame, disconnect } from './services/gameService';
+import { prisma } from './db';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 const app = express();
 const port = process.env.PORT || 3001;
 
-app.use(cors());
+app.use(
+  cors({ origin: process.env.FRONTEND_URL || 'http://localhost:3000', credentials: true })
+);
 app.use(morgan('dev'));
 app.use(express.json());
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'change-me',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+app.use(passport.initialize());
+app.use(passport.session());
+
+passport.serializeUser((user: any, done) => done(null, user.id));
+passport.deserializeUser(async (id: string, done) => {
+  const user = await prisma.user.findUnique({ where: { id } });
+  done(null, user);
+});
+
+passport.use(
+  new DiscordStrategy(
+    {
+      clientID: process.env.DISCORD_CLIENT_ID || '',
+      clientSecret: process.env.DISCORD_CLIENT_SECRET || '',
+      callbackURL: process.env.DISCORD_CALLBACK_URL || '',
+      scope: ['identify', 'email'],
+    },
+    async (_access, _refresh, profile, done) => {
+      try {
+        const avatarUrl = profile.avatar
+          ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
+          : '';
+        const data = {
+          discordId: profile.id,
+          name: profile.username,
+          avatarUrl,
+          email: (profile as any).email as string | undefined,
+        };
+        let user = await prisma.user.findUnique({ where: { discordId: data.discordId } });
+        if (!user) {
+          user = await prisma.user.create({ data });
+        } else {
+          user = await prisma.user.update({ where: { id: user.id }, data });
+        }
+        return done(null, user);
+      } catch (err) {
+        return done(err as Error);
+      }
+    }
+  )
+);
+
+function requireAuth(req: Request, res: Response, next: NextFunction) {
+  if (req.isAuthenticated()) return next();
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+function requireGM(req: Request, res: Response, next: NextFunction) {
+  const user = req.user as User | undefined;
+  if (req.isAuthenticated() && user?.role === 'GM') return next();
+  res.status(403).json({ error: 'Forbidden' });
+}
 
 app.get('/health', (_: Request, res: Response) => {
   res.json({ status: 'ok' });
@@ -23,15 +88,29 @@ app.get('/ping', (_: Request, res: Response) => {
   res.send('pong');
 });
 
-app.get('/games', async (_: Request, res: Response) => {
+app.get('/auth/discord', passport.authenticate('discord'));
+app.get(
+  '/auth/discord/callback',
+  passport.authenticate('discord', { failureRedirect: '/' }),
+  (_req, res) => {
+    res.redirect(process.env.FRONTEND_URL || 'http://localhost:3000');
+  }
+);
+
+app.get('/me', (req: Request, res: Response) => {
+  res.json(req.user || null);
+});
+
+app.get('/games', requireAuth, async (_: Request, res: Response) => {
   const games = await listGames();
   res.json(games);
 });
 
-app.post('/games', async (req: Request, res: Response) => {
+app.post('/games', requireGM, async (req: Request, res: Response) => {
   try {
     const data = CreateGameSchema.parse(req.body);
-    const game = await createGame(data);
+    const user = req.user as User;
+    const game = await createGame({ ...data, gmId: user.id, gmName: user.name });
     res.status(201).json(game);
   } catch (err) {
     res.status(400).json({ error: (err as Error).message });

--- a/apps/api/src/prisma-client-stub.ts
+++ b/apps/api/src/prisma-client-stub.ts
@@ -3,5 +3,10 @@ export class PrismaClient {
     findMany: () => [],
     create: (args: any) => args,
   };
+  user = {
+    findUnique: async (_: any) => ({} as any),
+    create: async ({ data }: any) => ({ id: '1', ...data }),
+    update: async ({ where, data }: any) => ({ id: where.id, ...data }),
+  };
   async $disconnect() {}
 }

--- a/apps/api/src/services/gameService.ts
+++ b/apps/api/src/services/gameService.ts
@@ -5,7 +5,7 @@ export async function listGames() {
   return prisma.game.findMany();
 }
 
-export async function createGame(data: CreateGame) {
+export async function createGame(data: CreateGame & { gmId: string; gmName: string }) {
   return prisma.game.create({ data });
 }
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": true,
     "rootDir": "src",
     "outDir": "dist",
+    "baseUrl": ".",
     "paths": {
       "@prisma/client": [
         "./src/prisma-client-stub"

--- a/apps/web/app/games/new/page.tsx
+++ b/apps/web/app/games/new/page.tsx
@@ -7,7 +7,6 @@ export default function NewGamePage() {
   const router = useRouter();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
   const [name, setName] = useState('');
-  const [gmName, setGmName] = useState('');
   const [players, setPlayers] = useState('');
   const [error, setError] = useState('');
 
@@ -16,7 +15,6 @@ export default function NewGamePage() {
     try {
       const data = CreateGameSchema.parse({
         name,
-        gmName,
         players: players.split(',').map(p => p.trim()).filter(Boolean)
       });
       const res = await fetch(`${apiUrl}/games`, {
@@ -38,10 +36,6 @@ export default function NewGamePage() {
       <div>
         <label className="block">Name</label>
         <input className="border p-2 w-full" value={name} onChange={e => setName(e.target.value)} />
-      </div>
-      <div>
-        <label className="block">GM Name</label>
-        <input className="border p-2 w-full" value={gmName} onChange={e => setGmName(e.target.value)} />
       </div>
       <div>
         <label className="block">Players (comma separated)</label>

--- a/apps/web/app/games/page.tsx
+++ b/apps/web/app/games/page.tsx
@@ -17,7 +17,6 @@ export default function GamesPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Games</h1>
-      <a href="/games/new" className="underline text-blue-600">Create new game</a>
       <ul className="mt-4 space-y-2">
         {games.map(g => (
           <li key={g.id} className="p-2 border rounded">

--- a/apps/web/app/header.tsx
+++ b/apps/web/app/header.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { User } from '@new-app/shared';
+
+export default function Header() {
+  const [user, setUser] = useState<User | null>(null);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+  useEffect(() => {
+    fetch(`${apiUrl}/me`, { credentials: 'include' })
+      .then(res => (res.ok ? res.json() : null))
+      .then(setUser)
+      .catch(() => setUser(null));
+  }, []);
+
+  const loginUrl = `${apiUrl}/auth/discord`;
+
+  return (
+    <header className="flex justify-between items-center mb-4">
+      <a href="/" className="text-xl font-bold">Game App</a>
+      {user ? (
+        <div className="flex items-center space-x-2">
+          <img src={user.avatarUrl} alt="avatar" className="w-8 h-8 rounded-full" />
+          <span>{user.name}</span>
+          {user.role === 'GM' && (
+            <a href="/games/new" className="ml-4 underline text-blue-600">Create New Game</a>
+          )}
+        </div>
+      ) : (
+        <a href={loginUrl} className="bg-[#5865F2] text-white px-4 py-2 rounded">
+          Login with Discord
+        </a>
+      )}
+    </header>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { ReactNode } from 'react';
+import Header from './header';
 
 export const metadata = {
   title: 'Game App',
@@ -8,7 +9,10 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="container mx-auto p-4">{children}</body>
+      <body className="container mx-auto p-4">
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -3,7 +3,15 @@ import { GameSchema } from './index'
 
 describe('GameSchema', () => {
   it('parses valid data', () => {
-    const data = { id: '1', name: 'D&D', gmName: 'Alice', players: ['Bob'] }
+    const data = {
+      id: '1',
+      name: 'D&D',
+      gmId: null,
+      gmName: 'Alice',
+      players: ['Bob'],
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    }
     expect(GameSchema.parse(data)).toEqual(data)
   })
 })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,17 +1,34 @@
 import { z } from 'zod';
 
+export const RoleEnum = z.enum(['PLAYER', 'GM']);
+export type Role = z.infer<typeof RoleEnum>;
+
+export const UserSchema = z.object({
+  id: z.string(),
+  discordId: z.string(),
+  name: z.string(),
+  avatarUrl: z.string(),
+  email: z.string().nullish(),
+  role: RoleEnum,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type User = z.infer<typeof UserSchema>;
+
 export const GameSchema = z.object({
   id: z.string(),
   name: z.string(),
+  gmId: z.string().nullish(),
   gmName: z.string(),
-  players: z.array(z.string())
+  players: z.array(z.string()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
 });
 export type Game = z.infer<typeof GameSchema>;
 
 export const CreateGameSchema = z.object({
   name: z.string(),
-  gmName: z.string(),
-  players: z.array(z.string())
+  players: z.array(z.string()),
 });
 export type CreateGame = z.infer<typeof CreateGameSchema>;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,8 +8,30 @@ generator client {
 }
 
 model Game {
-  id      String   @id @default(cuid())
-  name    String
-  gmName  String
-  players Json
+  id        String   @id @default(cuid())
+  name      String
+  gmId      String?
+  gm        User?    @relation(fields: [gmId], references: [id])
+  gmName    String
+  players   Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+enum Role {
+  PLAYER
+  GM
+}
+
+model User {
+  id        String   @id @default(cuid())
+  discordId String   @unique
+  name      String
+  avatarUrl String
+  email     String?
+  role      Role     @default(PLAYER)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  games Game[]
 }


### PR DESCRIPTION
## Summary
- add User and Role models in Prisma
- support Discord OAuth login and session-based auth
- restrict game creation to GMs
- expose auth routes and user endpoint
- update frontend with login button and header
- adjust new game form
- document new env vars and routes

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848995c19c88327b829568a3006d08f