### PR TITLE
Fix Prisma schema path in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma 
 
 You may also need to configure `no_proxy` or a mirror for `binaries.prisma.sh`.
 
+If the `init.sh` script reports that it can't find a Prisma schema, make sure you run it from the repository root. The script now specifies `--schema ../../prisma/schema.prisma` when calling Prisma commands.
+
 ## CI
 
 All pushes and pull requests trigger GitHub Actions defined in

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -3,6 +3,6 @@ set -e
 cd "$(dirname "$0")/.."
 pnpm install --no-frozen-lockfile
 pnpm approve-builds
-PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma generate --skip-download || true
-pnpm --filter @new-app/api exec prisma migrate deploy || true
+PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma generate --schema ../../prisma/schema.prisma --skip-download || true
+pnpm --filter @new-app/api exec prisma migrate deploy --schema ../../prisma/schema.prisma || true
 pnpm build


### PR DESCRIPTION
## Summary
- run prisma commands in `init.sh` with explicit schema path
- note schema path requirement in troubleshooting guide

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: GET https://registry.npmjs.org/... 504)*
- `pnpm build` *(fails: `turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b225e54b4832785ab77202aaac717