### PR TITLE
Fix Prisma env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma 
 
 You may also need to configure `no_proxy` or a mirror for `binaries.prisma.sh`.
 
-If the `init.sh` script reports that it can't find a Prisma schema, make sure you run it from the repository root. The script now specifies `--schema ../../prisma/schema.prisma` when calling Prisma commands.
+If the `init.sh` script reports that it can't find a Prisma schema or environment variables, make sure you run it from the repository root. The script now specifies `--schema ../../prisma/schema.prisma --dotenv ../../.env` when calling Prisma commands.
 
 ## CI
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -3,6 +3,6 @@ set -e
 cd "$(dirname "$0")/.."
 pnpm install --no-frozen-lockfile
 pnpm approve-builds
-PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma generate --schema ../../prisma/schema.prisma --skip-download || true
-pnpm --filter @new-app/api exec prisma migrate deploy --schema ../../prisma/schema.prisma || true
+PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @new-app/api exec prisma generate --schema ../../prisma/schema.prisma --dotenv ../../.env --skip-download || true
+pnpm --filter @new-app/api exec prisma migrate deploy --schema ../../prisma/schema.prisma --dotenv ../../.env || true
 pnpm build


### PR DESCRIPTION
## Summary
- ensure `prisma` CLI uses the root `.env`
- document new `--dotenv` usage

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_504)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b27aba1fc8327ae9e1612ae9d73e6